### PR TITLE
Fixing wl_display and wl_surface definitions.

### DIFF
--- a/src/vk-commands.lisp
+++ b/src/vk-commands.lisp
@@ -4697,7 +4697,7 @@ See WL_DISPLAY
 "
   (physical-device '%vk:physical-device physical-device :in :dispatchable :handle)
   (queue-family-index :uint32 queue-family-index :in :raw)
-  (display '(:struct %vk:wl_display) display :in :handle))
+  (display '%vk:wl_display display :in :handle))
 
 (defvkfun (create-win32-surface-khr
            %vk:create-win32-surface-khr

--- a/src/vk-expand-from-foreign.lisp
+++ b/src/vk-expand-from-foreign.lisp
@@ -2245,7 +2245,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
         %vk:supported-usage-flags)
        ,ptr
        (:struct %vk:surface-capabilities-khr))
-    (make-instance 'vk:surface-capabilities-khr
+     (make-instance 'vk:surface-capabilities-khr
                    :min-image-count %vk:min-image-count
                    :max-image-count %vk:max-image-count
                    :current-extent %vk:current-extent

--- a/src/vk-expand-to-foreign.lisp
+++ b/src/vk-expand-to-foreign.lisp
@@ -2302,8 +2302,8 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
     (setf %vk:s-type :wayland-surface-create-info-khr)
     (setf %vk:p-next (cffi:null-pointer))
     (setf %vk:flags (vk:flags ,value))
-    (setf %vk:display (vk-alloc:foreign-allocate-and-fill '(:struct %vk:wl_display) (vk:display ,value) ,ptr))
-    (setf %vk:surface (vk-alloc:foreign-allocate-and-fill '(:struct %vk:wl_surface) (vk:surface ,value) ,ptr))))
+    (setf %vk:display (vk:display ,value))
+    (setf %vk:surface (vk:surface ,value))))
 
 (defmethod cffi:expand-into-foreign-memory (value (type %vk:c-win32-surface-create-info-khr) ptr)
   `(cffi:with-foreign-slots

--- a/src/vk-translate-to-foreign.lisp
+++ b/src/vk-translate-to-foreign.lisp
@@ -2302,8 +2302,8 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
     (setf %vk:s-type :wayland-surface-create-info-khr)
     (setf %vk:p-next (cffi:null-pointer))
     (setf %vk:flags (vk:flags value))
-    (setf %vk:display (vk-alloc:foreign-allocate-and-fill '(:struct %vk:wl_display) (vk:display value) ptr))
-    (setf %vk:surface (vk-alloc:foreign-allocate-and-fill '(:struct %vk:wl_surface) (vk:surface value) ptr))))
+    (setf %vk:display (vk:display value))
+    (setf %vk:surface (vk:surface value))))
 
 (defmethod cffi:translate-into-foreign-memory (value (type %vk:c-win32-surface-create-info-khr) ptr)
   (cffi:with-foreign-slots

--- a/src/vulkan-commands.lisp
+++ b/src/vulkan-commands.lisp
@@ -977,7 +977,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 (defvkfun ("vkGetPhysicalDeviceWaylandPresentationSupportKHR" get-physical-device-wayland-presentation-support-khr) bool32
   (physical-device physical-device)
   (queue-family-index :uint32)
-  (display (:pointer (:struct wl_display))))
+  (display (:pointer wl_display)))
 
 (defvkfun ("vkCreateWin32SurfaceKHR" create-win32-surface-khr) checked-result
   (instance instance)

--- a/src/vulkan-types.lisp
+++ b/src/vulkan-types.lisp
@@ -901,9 +901,9 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 
 (defctype std-video-h265-level :uint32)
 
-(defcstruct wl_display)
+(defctype wl_display :pointer)
 
-(defcstruct wl_surface)
+(defctype wl_surface :pointer)
 
 (defcstruct security_attributes)
 
@@ -6114,8 +6114,8 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
   (s-type structure-type)
   (p-next (:pointer :void))
   (flags wayland-surface-create-flags-khr)
-  (display (:pointer (:struct wl_display)))
-  (surface (:pointer (:struct wl_surface))))
+  (display (:pointer wl_display))
+  (surface (:pointer wl_surface)))
 
 (defcstruct (win32-surface-create-info-khr :class c-win32-surface-create-info-khr)
   (s-type structure-type)


### PR DESCRIPTION
wl_dispay and wl_surface types were defined as foreign structures, this caused an error in vk:create-wayland-surface-khr. vk:wayland-surface-create-info-khr structure should contain pointers to wl_display and wl_surface but wrappers were trying to allocate and fill whole structures instead of using provided pointers.

Current changes make wrappers (as far as I undarstand at least) see those types as just a pointers now. Knowledge of those structures internas only required if you work with wayland, and in that case those definitions will be part of wayland wrapper, not vulkan wrapper.

With this cahnge wayland surface now can be created, only X11 worked before.